### PR TITLE
add flex & bison, remove ccache

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,7 +21,6 @@ cplusplusrpms:
   - autoconf
   - automake
   - bison
-  - ccache
   - gcc
   - flex
   - flex-devel

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,7 +21,6 @@ cplusplusrpms:
   - autoconf
   - automake
   - bison
-  - gcc
   - flex
   - flex-devel
   - file-devel

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -109,6 +109,7 @@
       - autoconf
       - automake
       - binutils
+      - bison
       - git
       - file-devel
       - flex

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -64,7 +64,7 @@
     - ansible_distribution_major_version|int == 6
   get_url:
     url: "{{ cern_repo_file }}"
-    dest: /etc/yum.repos.d
+    dest: /etc/yum.repos.d/slc6-scl.repo
     owner: root
     group: root
   register: network_access
@@ -111,6 +111,8 @@
       - binutils
       - git
       - file-devel
+      - flex
+      - flex-devel
       - make
       - openssl-devel
       - libstdc++-docs

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,6 +29,18 @@
   tags:
     - base_gcc
 
+- name: yum install gcc
+  when: ansible_os_family == 'RedHat' and not development_groupinstall
+  yum:
+    name: gcc
+    state: "{{ compilers_present }}"
+  register: network_access
+  until: network_access is success
+  retries: 10
+  delay: 2
+  tags:
+    - base_gcc
+
 - name: yum install development tools
   when: ansible_os_family == 'RedHat' and development_groupinstall
   yum:


### PR DESCRIPTION
ccache is in EPEL, as such it might be off-limits for RHEL shops that rely on RedHat support.

ccache can be installed with dockpack.base_utils if you don't care about this.