### PR TITLE
Fix for src option requires state to be 'link' or 'hard'

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -225,7 +225,6 @@
 
 - name: disable devtoolset
   file:
-    src: "/opt/rh/{{ cplusplus_devtoolset }}/enable"
     path: /etc/profile.d/devtoolset.sh
     state: absent
   when:


### PR DESCRIPTION
An issue was found in the new molecule test for base_boost with ansible 2.10