### PR TITLE
CHG allow for dts to be installed on centos 8

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -200,9 +200,11 @@
   retries: 10
   delay: 2
   when:
-    - ansible_os_family == 'RedHat' 
-    - (collections_enabled|bool and ansible_distribution_major_version|int < 8) or 
-      (DTSVER|int >= 9 and ansible_distribution_major_version|int == 8)
+    - ansible_os_family == 'RedHat'
+    - (collections_enabled|bool
+      and ansible_distribution_major_version|int < 8) or
+      (DTSVER|int >= 9
+      and ansible_distribution_major_version|int == 8)
   tags:
     - base_gcc
 
@@ -233,8 +235,10 @@
     mode: 0755
   when:
     - ansible_os_family == 'RedHat'
-    - (collections_enabled|bool and ansible_distribution_major_version|int < 8) or 
-      (DTSVER|int >= 9 and ansible_distribution_major_version|int == 8)
+    - (collections_enabled|bool
+      and ansible_distribution_major_version|int < 8) or
+      (DTSVER|int >= 9
+      and ansible_distribution_major_version|int == 8)
   tags:
     - base_gcc
     - notest
@@ -253,8 +257,10 @@
 - name: source devtoolset enable file
   when:
     - ansible_os_family == 'RedHat'
-    - (collections_enabled|bool and ansible_distribution_major_version|int < 8) or 
-      (DTSVER|int >= 9 and ansible_distribution_major_version|int == 8)
+    - (collections_enabled|bool
+      and ansible_distribution_major_version|int < 8) or
+      (DTSVER|int >= 9
+      and ansible_distribution_major_version|int == 8)
   set_fact:
     cmd_env: "source /opt/rh/{{ cplusplus_devtoolset }}/enable && "
   tags:


### PR DESCRIPTION
These changes allow for `gcc-toolset-9` or `gcc-toolset-10` to be installed on centos8 if DTS is set to 9 or 10.